### PR TITLE
Add timeline playback feature

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    YT: any;
+    onYouTubeIframeAPIReady: () => void;
+  }
+}
+export {};


### PR DESCRIPTION
## Summary
- add sequential playback for all timeline clips
- expose Play Timeline/Stop controls
- declare global YT types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684480def800832d93ab809da7b64156